### PR TITLE
bugfixes in initialization + shader-compilation. 

### DIFF
--- a/Common/ogldev_glfw_backend.cpp
+++ b/Common/ogldev_glfw_backend.cpp
@@ -196,6 +196,11 @@ bool GLFWBackendCreateWindow(uint Width, uint Height, bool isFullScreen, const c
 {
     GLFWmonitor* pMonitor = isFullScreen ? glfwGetPrimaryMonitor() : NULL;
 
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+
     s_pWindow = glfwCreateWindow(Width, Height, pTitle, pMonitor, NULL);
 
     if (!s_pWindow) {

--- a/tutorial20/lighting.fs
+++ b/tutorial20/lighting.fs
@@ -78,11 +78,11 @@ vec4 CalcPointLight(int Index, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(gPointLights[Index].Base, LightDirection, Normal);       
-    float Attenuation =  gPointLights[Index].Atten.Constant +                               
+    float AttenuationFactor =  gPointLights[Index].Atten.Constant +                               
                          gPointLights[Index].Atten.Linear * Distance +                      
                          gPointLights[Index].Atten.Exp * Distance * Distance;               
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 void main()                                                                                 

--- a/tutorial21/lighting.fs
+++ b/tutorial21/lighting.fs
@@ -88,11 +88,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal)                                                

--- a/tutorial24/lighting.fs
+++ b/tutorial24/lighting.fs
@@ -106,11 +106,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal, vec4 LightSpacePos)
     float ShadowFactor = CalcShadowFactor(LightSpacePos);                                   
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal, ShadowFactor);           
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal, vec4 LightSpacePos)                     

--- a/tutorial26/lighting.fs
+++ b/tutorial26/lighting.fs
@@ -107,11 +107,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal, vec4 LightSpacePos)
     float ShadowFactor = CalcShadowFactor(LightSpacePos);                                   
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal, ShadowFactor);           
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal, vec4 LightSpacePos)                            

--- a/tutorial30/lighting.fs
+++ b/tutorial30/lighting.fs
@@ -88,11 +88,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal)                                         

--- a/tutorial31/lighting.fs
+++ b/tutorial31/lighting.fs
@@ -89,11 +89,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal)                                         

--- a/tutorial33/lighting.fs
+++ b/tutorial33/lighting.fs
@@ -90,11 +90,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal)                                                

--- a/tutorial34/shaders/lighting.glsl
+++ b/tutorial34/shaders/lighting.glsl
@@ -107,11 +107,11 @@ vec4 CalcPointLight(PointLight l, VSOutput1 In)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, In);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, VSOutput1 In)                                         

--- a/tutorial36/shaders/dir_light_pass.fs
+++ b/tutorial36/shaders/dir_light_pass.fs
@@ -88,13 +88,13 @@ vec4 CalcPointLight(vec3 WorldPos, vec3 Normal)
 
     vec4 Color = CalcLightInternal(gPointLight.Base, LightDirection, WorldPos, Normal);
 
-    float Attenuation =  gPointLight.Atten.Constant +
+    float AttenuationFactor =  gPointLight.Atten.Constant +
                          gPointLight.Atten.Linear * Distance +
                          gPointLight.Atten.Exp * Distance * Distance;
 
-    Attenuation = max(1.0, Attenuation);
+    AttenuationFactor = max(1.0, AttenuationFactor);
 
-    return Color / Attenuation;
+    return Color / AttenuationFactor;
 }
 
 

--- a/tutorial36/shaders/point_light_pass.fs
+++ b/tutorial36/shaders/point_light_pass.fs
@@ -88,13 +88,13 @@ vec4 CalcPointLight(vec3 WorldPos, vec3 Normal)
 
     vec4 Color = CalcLightInternal(gPointLight.Base, LightDirection, WorldPos, Normal);
 
-    float Attenuation =  gPointLight.Atten.Constant +
+    float AttenuationFactor =  gPointLight.Atten.Constant +
                          gPointLight.Atten.Linear * Distance +
                          gPointLight.Atten.Exp * Distance * Distance;
 
-    Attenuation = max(1.0, Attenuation);
+    AttenuationFactor = max(1.0, AttenuationFactor);
 
-    return Color / Attenuation;
+    return Color / AttenuationFactor;
 }
 
 

--- a/tutorial37/shaders/dir_light_pass.fs
+++ b/tutorial37/shaders/dir_light_pass.fs
@@ -88,13 +88,13 @@ vec4 CalcPointLight(vec3 WorldPos, vec3 Normal)
 
     vec4 Color = CalcLightInternal(gPointLight.Base, LightDirection, WorldPos, Normal);
 
-    float Attenuation =  gPointLight.Atten.Constant +
+    float AttenuationFactor =  gPointLight.Atten.Constant +
                          gPointLight.Atten.Linear * Distance +
                          gPointLight.Atten.Exp * Distance * Distance;
 
-    Attenuation = max(1.0, Attenuation);
+    AttenuationFactor = max(1.0, AttenuationFactor);
 
-    return Color / Attenuation;
+    return Color / AttenuationFactor;
 }
 
 

--- a/tutorial37/shaders/point_light_pass.fs
+++ b/tutorial37/shaders/point_light_pass.fs
@@ -88,13 +88,13 @@ vec4 CalcPointLight(vec3 WorldPos, vec3 Normal)
 
     vec4 Color = CalcLightInternal(gPointLight.Base, LightDirection, WorldPos, Normal);
 
-    float Attenuation =  gPointLight.Atten.Constant +
+    float AttenuationFactor =  gPointLight.Atten.Constant +
                          gPointLight.Atten.Linear * Distance +
                          gPointLight.Atten.Exp * Distance * Distance;
 
-    Attenuation = max(1.0, Attenuation);
+    AttenuationFactor = max(1.0, AttenuationFactor);
 
-    return Color / Attenuation;
+    return Color / AttenuationFactor;
 }
 
 

--- a/tutorial38/shaders/skinning.fs
+++ b/tutorial38/shaders/skinning.fs
@@ -95,11 +95,11 @@ vec4 CalcPointLight(PointLight l, VSOutput In)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, In);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, VSOutput In)                                         

--- a/tutorial41/shaders/skinning.fs
+++ b/tutorial41/shaders/skinning.fs
@@ -98,11 +98,11 @@ vec4 CalcPointLight(PointLight l, VSOutput In)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, In);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, VSOutput In)                                         

--- a/tutorial42/shaders/lighting.fs
+++ b/tutorial42/shaders/lighting.fs
@@ -125,11 +125,11 @@ vec4 CalcPointLight(PointLight l, VSOutput In)
     float ShadowFactor = CalcShadowFactor(In.LightSpacePos);
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, In, ShadowFactor);
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, VSOutput In)

--- a/tutorial43/shaders/lighting.fs
+++ b/tutorial43/shaders/lighting.fs
@@ -87,11 +87,11 @@ vec4 CalcPointLight(PointLight l, VSOutput In)
     float ShadowFactor = CalcShadowFactor(LightDirection);
     LightDirection = normalize(LightDirection);                                                                                            
     vec4 Color = CalcLightInternal(l.Base, LightDirection, In, ShadowFactor);
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;  
                                                                                            
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 out vec4 FragColor;

--- a/tutorial45/shaders/lighting.fs
+++ b/tutorial45/shaders/lighting.fs
@@ -107,11 +107,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal)                                                

--- a/tutorial46/shaders/lighting.fs
+++ b/tutorial46/shaders/lighting.fs
@@ -107,11 +107,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal);                         
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal)                                                

--- a/tutorial47/Shaders/lighting.fs
+++ b/tutorial47/Shaders/lighting.fs
@@ -107,11 +107,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal, vec4 LightSpacePos)
     float ShadowFactor = CalcShadowFactor(LightSpacePos);
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal, ShadowFactor);           
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal, vec4 LightSpacePos)                     

--- a/tutorial49/Shaders/lighting.fs
+++ b/tutorial49/Shaders/lighting.fs
@@ -108,11 +108,11 @@ vec4 CalcPointLight(PointLight l, vec3 Normal)
     LightDirection = normalize(LightDirection);                                             
                                                                                             
     vec4 Color = CalcLightInternal(l.Base, LightDirection, Normal, 1.0);           
-    float Attenuation =  l.Atten.Constant +                                                 
+    float AttenuationFactor =  l.Atten.Constant +                                                 
                          l.Atten.Linear * Distance +                                        
                          l.Atten.Exp * Distance * Distance;                                 
                                                                                             
-    return Color / Attenuation;                                                             
+    return Color / AttenuationFactor;                                                             
 }                                                                                           
                                                                                             
 vec4 CalcSpotLight(SpotLight l, vec3 Normal)                     


### PR DESCRIPTION
Trying to run the samples in vmware fusion, in windows 10 with msvc2015.
Ran into the following issues
- When running the tutorial (45 in my case) initialization fails, reporting that glsl3.30 is not supported, only 1.0, 1.10, 1.20 en ES 1.0 and 3.0 are supported. Explicitly specifying that we want glsl 3.3 before creating the windows avoids this issue
- Next issue is that the shader won't compile because it say it's expecting a '(' after Attenuation, so it must be seeing the variable as a function. I'm pretty sure I also ran into this when using that variable name in my own shaders on MacOS with X-code. Simply renamed all occurrences of that variable to avoid the issue.

Note: This is the first time I'm doing a pull-request, so if sth is wrong it would be nice to get some info on what should be done differently - thx.
