### PR TITLE
Fix typo in FrustumCulling::IsCubeInside()

### DIFF
--- a/Include/ogldev_math_3d.h
+++ b/Include/ogldev_math_3d.h
@@ -827,7 +827,7 @@ public:
                 return true;
             }
 
-            if (m_clipPlanes[i].Dot(BottomRightNear) > 0) {
+            if (m_clipPlanes[i].Dot(BottomRightFar) > 0) {
                 return true;
             }
         }


### PR DESCRIPTION
With options `-Wall -Wextra` compiler reported `BottomRightFar` is not used:
```
../Include/ogldev_math_3d.h: In member function 'bool FrustumCulling::IsCubeInside(const Vector3f&, float)':
../Include/ogldev_math_3d.h:798:18: warning: variable 'BottomRightFar' set but not used [-Wunused-but-set-variable]
  798 |         Vector4f BottomRightFar  = Center4 + Vector4f( HalfSize, -HalfSize,  HalfSize, 1.0f);
```
For one plane `BottomRightNear`  dot product is calculated twice. I'm sure there is a typo and one of them should be `BottomRightFar`