### PR TITLE
Fix: Crash trying to enter unavail game mode

### DIFF
--- a/tutorial15/tutorial15.cpp
+++ b/tutorial15/tutorial15.cpp
@@ -212,7 +212,11 @@ int main(int argc, char** argv)
     char game_mode_string[64];
     snprintf(game_mode_string, sizeof(game_mode_string), "%dx%d@60", WINDOW_WIDTH, WINDOW_HEIGHT);
     glutGameModeString(game_mode_string);
-    glutEnterGameMode();
+    if (glutGameModeGet(GLUT_GAME_MODE_POSSIBLE))
+        glutEnterGameMode();
+    else {
+        fprintf(stderr, "Error: Requested game mode, '%s', not available.\n", game_mode_string);
+    }
 
     InitializeGlutCallbacks();
 

--- a/tutorial15/tutorial15.cpp
+++ b/tutorial15/tutorial15.cpp
@@ -212,9 +212,9 @@ int main(int argc, char** argv)
     char game_mode_string[64];
     snprintf(game_mode_string, sizeof(game_mode_string), "%dx%d@60", WINDOW_WIDTH, WINDOW_HEIGHT);
     glutGameModeString(game_mode_string);
-    if (glutGameModeGet(GLUT_GAME_MODE_POSSIBLE))
+    if (glutGameModeGet(GLUT_GAME_MODE_POSSIBLE)) {
         glutEnterGameMode();
-    else {
+    } else {
         fprintf(stderr, "Error: Requested game mode, '%s', not available.\n", game_mode_string);
     }
 

--- a/tutorial16/tutorial16.cpp
+++ b/tutorial16/tutorial16.cpp
@@ -244,9 +244,9 @@ int main(int argc, char** argv)
     glutCreateWindow("Tutorial 16");
     const char* game_mode_string = "1920x12@32";
     glutGameModeString(game_mode_string);
-    if (glutGameModeGet(GLUT_GAME_MODE_POSSIBLE))
+    if (glutGameModeGet(GLUT_GAME_MODE_POSSIBLE)) {
         glutEnterGameMode();
-    else {
+    } else {
         fprintf(stderr, "Error: Requested game mode, '%s', not available.\n", game_mode_string);
     }
 

--- a/tutorial16/tutorial16.cpp
+++ b/tutorial16/tutorial16.cpp
@@ -242,8 +242,13 @@ int main(int argc, char** argv)
     glutInitWindowSize(WINDOW_WIDTH, WINDOW_HEIGHT);
     glutInitWindowPosition(100, 100);
     glutCreateWindow("Tutorial 16");
-    glutGameModeString("1920x12@32");
-    glutEnterGameMode();
+    const char* game_mode_string = "1920x12@32";
+    glutGameModeString(game_mode_string);
+    if (glutGameModeGet(GLUT_GAME_MODE_POSSIBLE))
+        glutEnterGameMode();
+    else {
+        fprintf(stderr, "Error: Requested game mode, '%s', not available.\n", game_mode_string);
+    }
 
     InitializeGlutCallbacks();
 


### PR DESCRIPTION
# Background

Trying to run tutorial15 crashed my system forcing a reboot.

After looking into it I found that it was crashing while trying to execute `glutEnterGameMode` due to the requested game mode not being available on my system. After taking a look at the API, it seems glut provides a method that can be used for checking whether the currently configured game mode string is supported by the current system before attempting activate it. If it returns false, I print an error message to stderr and skip calling `glutEnterGameMode`, effectively falling back to the standard windowed mode. Alternatively you could exit with an error, but falling back to the windowed mode worked just fine so that's what I opted for. I modified tutorial16 in the same way. 

As a side note, I noticed that the game mode string in tutorial16 is currently being set to `1920x12@32`. I'm not sure if this was intentional or not so I haven't changed it, but I'm guessing this was probably intended to be 1920x1200 resolution, which is the resolution used in tutorial15. It also currently appears to be attempting to set the refresh rate to 32Hz due to the use of the `@` prefix. I'm guessing this was rather intended to be `:32` for specifying 32 bit truecolor. Let me know if you'd like me to update this string as well.

# Changes

 - Modified `tutorial15/tutorial15.cpp`

   - Avoid possible system crash by calling `glutGameModeGet(GLUT_GAME_MODE_POSSIBLE)` before attempting to enter game mode.
 
 - Modified `tutorial16/tutorial16.cpp`

   - Avoid possible system crash by calling `glutGameModeGet(GLUT_GAME_MODE_POSSIBLE)` before attempting to enter game mode.

# Results

After the above changes, my system no longer crashes when attempting to run tutorial15 or tutorial16 with the hardcoded game mode string. Instead it prints a message to stderr and falls back to the standard windowed mode.