### PR TITLE
Add --recurse-submodules to git clone command

### DIFF
--- a/web/instructions.html
+++ b/web/instructions.html
@@ -27,7 +27,7 @@ that supports version 3.3 of the OpenGL spec at least (though some of
 the tutorials, e.g. Tessellation, require 4.x support). The code is maintained on github and you can get using:
 </p>
 <p>
-    git clone https://github.com/emeiri/ogldev.git
+    git clone --recurse-submodules https://github.com/emeiri/ogldev.git
 </p>
 <p>Then execute the following in order to install the dependencies:</p>
 <p>


### PR DESCRIPTION
You could do `git submodule update --init` as well.

Without one of these, the `Common/3rdparty/meshoptimizer` directory won't be populated and some of the tutorials will fail to build, complaining about a missing header file.