### PR TITLE
Fix compilation error in many tutorials starting with tutorial16

### DIFF
--- a/Common/ogldev_texture.cpp
+++ b/Common/ogldev_texture.cpp
@@ -186,7 +186,7 @@ void Texture::LoadInternalDSA(const void* pImageData)
 void Texture::LoadF32(int Width, int Height, const float* pImageData)
 {
     if (!IsGLVersionHigher(4, 5)) {
-        OGLDEV_ERROR("Non DSA version is not implemented\n");
+        OGLDEV_ERROR0("Non DSA version is not implemented\n");
     }
 
     m_imageWidth = Width;


### PR DESCRIPTION
Without this change many tutorials starting with tutorial16 fail with the following error:
```
In file included from ../Common/ogldev_texture.cpp:21:
../Common/ogldev_texture.cpp: In member function ‘void Texture::LoadF32(int, int, const float*)’:
../Include/ogldev_util.h:50:80: error: expected primary-expression before ‘)’ token
   50 | #define OGLDEV_ERROR(msg, ...) OgldevError(__FILE__, __LINE__, msg, __VA_ARGS__)
      |                                                                                ^
../Common/ogldev_texture.cpp:189:9: note: in expansion of macro ‘OGLDEV_ERROR’
  189 |         OGLDEV_ERROR("Non DSA version is not implemented\n");
      |         ^~~~~~~~~~~~
```