### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Include/assimp5/assimp.orig/*
 VulkanClear/*
 *.spv
 *.cap
+.vs/


### PR DESCRIPTION
VS 2022 .vs directory can be ignored. It can be recreated by VS.