### PR TITLE
Avoid camera glitch when it becomes mobile again

### DIFF
--- a/tutorial32_youtube/tutorial32.cpp
+++ b/tutorial32_youtube/tutorial32.cpp
@@ -263,6 +263,9 @@ public:
     {
         if (m_mobileCamera) {
             m_pGameCamera->OnMouse(x, y);
+        } else {
+            // avoid a camera glitch when it becomes mobile again
+            m_pGameCamera->UpdateMousePosSilent(x, y);
         }
 
         if (m_leftMouseButton.IsPressed) {


### PR DESCRIPTION
When camera is not mobile (m_pmobileCamera = false), user may move the mouse and then make it mobile again. It creates a brutal camera movement (a glitch), because mouse position has not been updated.